### PR TITLE
QA Fail 7172/Fix for verse spans not giving invalidated selections warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "checking-tool-wrapper",
-  "version": "7.0.0-alpha.3",
+  "version": "7.0.1-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "7.0.0-alpha.3",
+      "version": "7.0.1-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@material-ui/icons": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "main": "lib/index.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/src/localStorage/saveMethods.js
+++ b/src/localStorage/saveMethods.js
@@ -10,6 +10,7 @@ import { PROJECT_CHECKDATA_DIRECTORY, PROJECT_INDEX_FOLDER_PATH } from '../commo
  *  @example comments, bookmarks, selections, verseEdits etc.
  * @param {String} modifiedTimestamp - timestamp.
  * that contains the specific timestamp.
+ * @param {String} projectSaveLocation
  * @return {String} save path.
  */
 function generateSavePath(contextId, checkDataName, modifiedTimestamp, projectSaveLocation) {
@@ -17,7 +18,7 @@ function generateSavePath(contextId, checkDataName, modifiedTimestamp, projectSa
     if (projectSaveLocation && contextId && modifiedTimestamp) {
       const bookId = contextId.reference.bookId;
       const chapter = contextId.reference.chapter.toString();
-      const verse = contextId.reference.verse.toString();
+      const verse = contextId.verseSpan || contextId.reference.verse.toString();
       const fileName = modifiedTimestamp + '.json';
       const savePath = path.join(
         projectSaveLocation,


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fixed problem that checks were being saved under the verse number in the original language.  Changed to save using the verse span (e.g '1-2').

#### Please include detailed Test instructions for your pull request:
- test using build: https://github.com/unfoldingWord/translationCore/actions/runs/1688952588 

- [ ] start tCore
- [ ] download repo: https://git.door43.org/lrsallee/en_ust_gal_book
- [ ] for tW tool, select english as GL and launch tool
- [ ] under apostle, for '1:1-2' select text such as:
![Screen Shot 2022-01-12 at 12 59 39 PM](https://user-images.githubusercontent.com/14238574/149196186-b6056107-ce96-443e-beff-5323f0ac4b65.png)

- [ ] save selection
- [ ] open wa tool
- [ ] edit verse 1:1-2 and change text for selection in tW such as:
![Screen Shot 2022-01-12 at 1 02 42 PM](https://user-images.githubusercontent.com/14238574/149196789-d8837680-119a-45ec-8b1e-8f68ef7de9b4.png)

- [ ] select a reason and click save
- [ ] should see warning about selections invalidated. Click OK
- [ ] open tw tool
- [ ] should immediately see warning that selection invalidated. Click OK
- [ ] should see visual warnings that previous selection for 1:1-2 were invalidated, edited and selection should be gone such as:
![Screen Shot 2022-01-12 at 1 07 52 PM](https://user-images.githubusercontent.com/14238574/149197956-4d54c260-6480-47a1-8689-05c0977f07bb.png)

